### PR TITLE
Check whole line, so as not to return a false-positive if the EAC workaround has previously been commented out.

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -1436,7 +1436,7 @@ eac_workaround() {
     eac_hosts="127.0.0.1 modules-cdn.eac-prod.on.epicgames.com"
 
     # Check if EAC workaround is already applied
-    if grep "$eac_hosts" /etc/hosts; then
+    if grep -x "$eac_hosts" /etc/hosts; then
         message info "The Easy Anti-Cheat workaround has already been applied.\nYou're all set!"
         return 1
     fi


### PR DESCRIPTION
Came across this scenario myself, where I had previously commented out the EAC workaround.

This utilises greps `--line-regexp` to match on the entire line, thus not returning if someone has edited/commented out the entry in hosts.