### PR TITLE
Add PowerShell Wrapper to LUG install script

### DIFF
--- a/lutris-sc-install.json
+++ b/lutris-sc-install.json
@@ -31,75 +31,99 @@
       "humblestoreid_real": "",
       "script": {
         "files": [
-          {
-            "client": "https://install.robertsspaceindustries.com/star-citizen/RSI-Setup-1.6.8.exe"
-          }
+            {
+                "client": "https://install.robertsspaceindustries.com/star-citizen/RSI-Setup-1.6.9.exe"
+            },
+            {
+                "prelaunch": "https://gist.githubusercontent.com/GloriousEggroll/289ff1051743c6f89e4b1189f5da5ea8/raw/88ec1898f3d31df60d17125e609f9671db9cf749/sc-prelaunch.sh"
+            },
+            {
+                "powershell_wrapper": "https://github.com/PietJankbal/powershell-wrapper-for-wine/raw/c6a520bf04b0e00cf7fdca66603332f9658ca8f9/install_pwshwrapper.exe"
+            }
         ],
         "game": {
-          "args": "--locale=$INPUT_LOCALE",
-          "exe": "$GAMEDIR/drive_c/Program Files/Roberts Space Industries/RSI Launcher/RSI Launcher.exe",
-          "prefix": "$GAMEDIR"
+            "args": "--locale=$INPUT_LOCALE",
+            "exe": "$GAMEDIR/drive_c/Program Files/Roberts Space Industries/RSI Launcher/RSI Launcher.exe",
+            "prefix": "$GAMEDIR"
         },
         "install_complete_text": "Installation Complete!\r\n\r\nPlease see our Wiki for important news and configuration requirements:\r\n\r\nhttps://starcitizen-lug.github.io",
         "installer": [
-          {
-            "task": {
-              "arch": "win64",
-              "description": "Creating Wine prefix",
-              "name": "create_prefix",
-              "prefix": "$GAMEDIR"
+            {
+                "task": {
+                    "arch": "win64",
+                    "description": "Creating Wine prefix",
+                    "name": "create_prefix",
+                    "prefix": "$GAMEDIR"
+                }
+            },
+            {
+                "task": {
+                    "arch": "win64",
+                    "description": "Installing PowerShell wrapper",
+                    "executable": "powershell_wrapper",
+                    "name": "wineexec",
+                    "prefix": "$GAMEDIR"
+                }
+            },
+            {
+                "task": {
+                    "arch": "win64",
+                    "args": "-noni -c 'echo \"done\"'",
+                    "description": "Configuring PowerShell wrapper",
+                    "executable": "powershell",
+                    "name": "wineexec",
+                    "prefix": "$GAMEDIR"
+                }
+            },
+            {
+                "task": {
+                    "app": "arial vcrun2019 win10",
+                    "arch": "win64",
+                    "description": "Installing dlls",
+                    "name": "winetricks",
+                    "prefix": "$GAMEDIR"
+                }
+            },
+            {
+                "task": {
+                    "arch": "win64",
+                    "args": "/S",
+                    "description": "Installing client",
+                    "executable": "client",
+                    "name": "wineexec",
+                    "prefix": "$GAMEDIR"
+                }
+            },
+            {
+                "chmodx": "prelaunch"
+            },
+            {
+                "copy": {
+                    "dst": "$GAMEDIR",
+                    "src": "prelaunch"
+                }
             }
-          },
-          {
-            "task": {
-              "app": "arial vcrun2019 win10",
-              "arch": "win64",
-              "description": "Installing dlls",
-              "name": "winetricks",
-              "prefix": "$GAMEDIR"
-            }
-          },
-          {
-            "task": {
-              "arch": "win64",
-              "args": "/S",
-              "description": "Installing client",
-              "executable": "client",
-              "name": "wineexec",
-              "prefix": "$GAMEDIR"
-            }
-          },
-          {
-            "execute": {
-              "command": "mkdir -p \"$GAMEDIR/drive_c/Program Files/Roberts Space Industries/StarCitizen/\"{LIVE,PTU}",
-              "description": "Creating game path"
-            }
-          }
         ],
         "system": {
-          "env": {
-            "DXVK_HUD": 0,
-            "__GL_SHADER_DISK_CACHE": 1,
-            "__GL_SHADER_DISK_CACHE_SIZE": 1073741824,
-            "__GL_THREADED_OPTIMIZATIONS": 1,
-            "SteamGameId": "starcitizen"
-          },
-          "prelaunch_command": "/usr/bin/sh -c 'if [ -d \"$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/EasyAntiCheat\" ]; then rm -rf \"$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/EasyAntiCheat\"; fi'",
-          "prefer_system_libs": false
+            "env": {
+                "DXVK_HUD": 0,
+                "SteamGameId": "starcitizen",
+                "__GL_SHADER_DISK_CACHE": 1,
+                "__GL_SHADER_DISK_CACHE_SIZE": 1073741824,
+                "__GL_THREADED_OPTIMIZATIONS": 1
+            },
+            "prefer_system_libs": false,
+            "prelaunch_command": "$GAMEDIR/sc-prelaunch.sh"
         },
         "wine": {
-          "dxvk": true,
-          "esync": true,
-          "fsync": true,
-          "dxvk_nvapi": false,
-          "overrides": {
-            "libglesv2": "builtin",
-            "nvapi,nvapi64": "disabled",
-            "powershell.exe": "disabled"
-          },
-          "system_winetricks": false
+            "dxvk_nvapi": false,
+            "overrides": {
+                "amd_ags_x64": "builtin",
+                "libglesv2": "builtin",
+                "nvapi,nvapi64": "disabled"
+            },
+            "system_winetricks": false
         }
-      }
     }
   ]
 }

--- a/lutris-sc-install.json
+++ b/lutris-sc-install.json
@@ -31,99 +31,100 @@
       "humblestoreid_real": "",
       "script": {
         "files": [
-            {
-                "client": "https://install.robertsspaceindustries.com/star-citizen/RSI-Setup-1.6.9.exe"
-            },
-            {
-                "prelaunch": "https://gist.githubusercontent.com/GloriousEggroll/289ff1051743c6f89e4b1189f5da5ea8/raw/88ec1898f3d31df60d17125e609f9671db9cf749/sc-prelaunch.sh"
-            },
-            {
-                "powershell_wrapper": "https://github.com/PietJankbal/powershell-wrapper-for-wine/raw/c6a520bf04b0e00cf7fdca66603332f9658ca8f9/install_pwshwrapper.exe"
-            }
+          {
+            "client": "https://install.robertsspaceindustries.com/star-citizen/RSI-Setup-1.6.9.exe"
+          },
+          {
+            "prelaunch": "https://gist.githubusercontent.com/GloriousEggroll/289ff1051743c6f89e4b1189f5da5ea8/raw/88ec1898f3d31df60d17125e609f9671db9cf749/sc-prelaunch.sh"
+          },
+          {
+            "powershell_wrapper": "https://github.com/PietJankbal/powershell-wrapper-for-wine/raw/c6a520bf04b0e00cf7fdca66603332f9658ca8f9/install_pwshwrapper.exe"
+          }
         ],
         "game": {
-            "args": "--locale=$INPUT_LOCALE",
-            "exe": "$GAMEDIR/drive_c/Program Files/Roberts Space Industries/RSI Launcher/RSI Launcher.exe",
-            "prefix": "$GAMEDIR"
+          "args": "--locale=$INPUT_LOCALE",
+          "exe": "$GAMEDIR/drive_c/Program Files/Roberts Space Industries/RSI Launcher/RSI Launcher.exe",
+          "prefix": "$GAMEDIR"
         },
         "install_complete_text": "Installation Complete!\r\n\r\nPlease see our Wiki for important news and configuration requirements:\r\n\r\nhttps://starcitizen-lug.github.io",
         "installer": [
-            {
-                "task": {
-                    "arch": "win64",
-                    "description": "Creating Wine prefix",
-                    "name": "create_prefix",
-                    "prefix": "$GAMEDIR"
-                }
-            },
-            {
-                "task": {
-                    "arch": "win64",
-                    "description": "Installing PowerShell wrapper",
-                    "executable": "powershell_wrapper",
-                    "name": "wineexec",
-                    "prefix": "$GAMEDIR"
-                }
-            },
-            {
-                "task": {
-                    "arch": "win64",
-                    "args": "-noni -c 'echo \"done\"'",
-                    "description": "Configuring PowerShell wrapper",
-                    "executable": "powershell",
-                    "name": "wineexec",
-                    "prefix": "$GAMEDIR"
-                }
-            },
-            {
-                "task": {
-                    "app": "arial vcrun2019 win10",
-                    "arch": "win64",
-                    "description": "Installing dlls",
-                    "name": "winetricks",
-                    "prefix": "$GAMEDIR"
-                }
-            },
-            {
-                "task": {
-                    "arch": "win64",
-                    "args": "/S",
-                    "description": "Installing client",
-                    "executable": "client",
-                    "name": "wineexec",
-                    "prefix": "$GAMEDIR"
-                }
-            },
-            {
-                "chmodx": "prelaunch"
-            },
-            {
-                "copy": {
-                    "dst": "$GAMEDIR",
-                    "src": "prelaunch"
-                }
+          {
+            "task": {
+              "arch": "win64",
+              "description": "Creating Wine prefix",
+              "name": "create_prefix",
+              "prefix": "$GAMEDIR"
             }
+          },
+          {
+            "task": {
+              "arch": "win64",
+              "description": "Installing PowerShell wrapper",
+              "executable": "powershell_wrapper",
+              "name": "wineexec",
+              "prefix": "$GAMEDIR"
+            }
+          },
+          {
+            "task": {
+              "arch": "win64",
+              "args": "-noni -c 'echo \"done\"'",
+              "description": "Configuring PowerShell wrapper",
+              "executable": "powershell",
+              "name": "wineexec",
+              "prefix": "$GAMEDIR"
+            }
+          },
+          {
+            "task": {
+              "app": "arial vcrun2019 win10",
+              "arch": "win64",
+              "description": "Installing dlls",
+              "name": "winetricks",
+              "prefix": "$GAMEDIR"
+            }
+          },
+          {
+            "task": {
+              "arch": "win64",
+              "args": "/S",
+              "description": "Installing client",
+              "executable": "client",
+              "name": "wineexec",
+              "prefix": "$GAMEDIR"
+            }
+          },
+          {
+            "chmodx": "prelaunch"
+          },
+          {
+            "copy": {
+              "dst": "$GAMEDIR",
+              "src": "prelaunch"
+            }
+          }
         ],
         "system": {
-            "env": {
-                "DXVK_HUD": 0,
-                "SteamGameId": "starcitizen",
-                "__GL_SHADER_DISK_CACHE": 1,
-                "__GL_SHADER_DISK_CACHE_SIZE": 1073741824,
-                "__GL_THREADED_OPTIMIZATIONS": 1
-            },
-            "prefer_system_libs": false,
-            "prelaunch_command": "$GAMEDIR/sc-prelaunch.sh"
+          "env": {
+            "DXVK_HUD": 0,
+            "SteamGameId": "starcitizen",
+            "__GL_SHADER_DISK_CACHE": 1,
+            "__GL_SHADER_DISK_CACHE_SIZE": 1073741824,
+            "__GL_THREADED_OPTIMIZATIONS": 1
+          },
+          "prefer_system_libs": false,
+          "prelaunch_command": "$GAMEDIR/sc-prelaunch.sh"
         },
         "wine": {
-            "dxvk_nvapi": false,
-            "overrides": {
-                "amd_ags_x64": "builtin",
-                "libglesv2": "builtin",
-                "nvapi,nvapi64": "disabled"
-            },
-            "system_winetricks": false
+          "dxvk_nvapi": false,
+          "overrides": {
+            "amd_ags_x64": "builtin",
+            "libglesv2": "builtin",
+            "nvapi,nvapi64": "disabled"
+          },
+          "system_winetricks": false
         }
+      }
     }
   ]
 }


### PR DESCRIPTION
Howdy!, this is modified based off of the current installer available on [Lutris](https://lutris.net/games/star-citizen)

This fixes the issue of the RSI Launcher not being able to create directories, as well as allows the launcher to update itself.

I do know that disabling PowerShell at least in part allows the launcher to self-update, but getting a 'working' PowerShell binary allows the launcher to create directories, and may help it do other things if new functionality is added.

There are probably limitations to this PowerShell solution as PowerShell Core (The shell this wrapper is for) doesn't provide some of the WMI functions, etc. that the older "Windows PowerShell" has.

In a perfect world this CEF based launcher would use JavaScript functions to touch the filesystem.. but oh well.

The added amd_ags_x64 override is in place since this game uses amd ags, and there is a re-implementation of some DX11 extension functions included in Wine GE (As well as Proton). 

I'm not fully sure if Star Citizen makes use of any of the re-implemented functions, but if it does there is in theory some performance improvements available, regardless of graphics vendor. 