### PR TITLE
eac workaround

### DIFF
--- a/lib/lutris-starcitizen.json
+++ b/lib/lutris-starcitizen.json
@@ -81,7 +81,7 @@
             "DXVK_HUD": 0,
             "__GL_SHADER_DISK_CACHE": 1,
             "__GL_SHADER_DISK_CACHE_SIZE": 1073741824,
-            "SteamGameId": "starcitizen"
+            "EOS_USE_ANTICHEATCLIENTNULL": "1"
           },
           "prelaunch_command": "/usr/bin/sh -c 'if [ -d \"$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/EasyAntiCheat\" ]; then rm -rf \"$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/EasyAntiCheat\"; fi'",
           "prefer_system_libs": false

--- a/lib/lutris-starcitizen.json
+++ b/lib/lutris-starcitizen.json
@@ -17,7 +17,7 @@
       "notes": "Performance may be choppy for the first couple minutes after visiting a new place or performing a new activity while shaders compile. Subsequent arrival should not be choppy.\r\n\r\nPlease make sure you have all Wine dependencies properly installed or your game may crash during start up. To prevent crashes in areas with lots of geometry, the game needs a resource limit named \"vm.max_map_count\" increased. See our wiki's Quick Start Guide for more information and instructions.\r\n\r\nSee you in the 'verse!",
       "credits": "",
       "created_at": "2023-03-24T06:40:19.908354Z",
-      "updated_at": "2024-01-05T16:52:37.863257Z",
+      "updated_at": "2024-03-01T17:38:13.536835Z",
       "draft": false,
       "published": true,
       "published_by": null,
@@ -83,7 +83,6 @@
             "__GL_SHADER_DISK_CACHE_SIZE": 1073741824,
             "EOS_USE_ANTICHEATCLIENTNULL": "1"
           },
-          "prelaunch_command": "/usr/bin/sh -c 'if [ -d \"$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/EasyAntiCheat\" ]; then rm -rf \"$WINEPREFIX/drive_c/users/$USER/AppData/Roaming/EasyAntiCheat\"; fi'",
           "prefer_system_libs": false
         },
         "wine": {

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -182,7 +182,6 @@ runners_dir_flatpak="$lutris_flatpak_dir/data/lutris/runners/wine"
 runner_sources=(
     "GloriousEggroll" "https://api.github.com/repos/GloriousEggroll/wine-ge-custom/releases"
     "RawFox" "https://api.github.com/repos/starcitizen-lug/raw-wine/releases"
-    "/dev/null" "https://api.github.com/repos/gort818/wine-sc-lug/releases"
 )
 
 ######## DXVK ##############################################################
@@ -200,10 +199,7 @@ dxvk_dir_flatpak="$lutris_flatpak_dir/data/lutris/runtime/dxvk"
 # ie. "Ph42oN GPL+Async" "https://gitlab.com/api/v4/projects/Ph42oN%2Fdxvk-gplasync/releases"
 dxvk_sources=(
     "doitsujin (standard dxvk)" "https://api.github.com/repos/doitsujin/dxvk/releases"
-    "Sporif Async" "https://api.github.com/repos/Sporif/dxvk-async/releases"
     "Ph42oN GPL+Async" "https://gitlab.com/api/v4/projects/Ph42oN%2Fdxvk-gplasync/releases"
-    "gnusenpai" "https://api.github.com/repos/gnusenpai/dxvk/releases"
-    "/dev/null" "https://api.github.com/repos/gort818/dxvk/releases"
 )
 
 ######## Requirements ######################################################


### PR DESCRIPTION
ngh was poking around the json workaround option and found this variable was now available with the updated eac SDK and a few of us tried it out and it worked fine

thought it might be time to remove some of the old dxvk and wine sources until needed again