### PR TITLE
Set Prefer System Libraries to true

### DIFF
--- a/lib/lutris-starcitizen.json
+++ b/lib/lutris-starcitizen.json
@@ -83,7 +83,7 @@
             "__GL_SHADER_DISK_CACHE_SIZE": 1073741824,
             "EOS_USE_ANTICHEATCLIENTNULL": "1"
           },
-          "prefer_system_libs": false
+          "prefer_system_libs": true
         },
         "wine": {
           "dxvk": true,


### PR DESCRIPTION
Having Prefer System Libraries set to false by default is the primary cause of audio issues for many folks.