### PR TITLE
add Kron4ek wine runner source

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -182,6 +182,7 @@ runners_dir_flatpak="$lutris_flatpak_dir/data/lutris/runners/wine"
 runner_sources=(
     "GloriousEggroll" "https://api.github.com/repos/GloriousEggroll/wine-ge-custom/releases"
     "RawFox" "https://api.github.com/repos/starcitizen-lug/raw-wine/releases"
+    "Kron4ek" "https://api.github.com/repos/Kron4ek/Wine-Builds/releases"
 )
 
 ######## DXVK ##############################################################
@@ -1703,7 +1704,7 @@ download_select_install() {
 
         # Get the file name minus the extension
         case "${download_versions[i]}" in
-            *.sha*sum | *.ini | proton*)
+            *.sha*sum | *.ini | proton* | *.txt)
                 # Ignore hashes, configs, and proton downloads
                 continue
                 ;;


### PR DESCRIPTION
The 2.0 RSI Launcher needs a staging wine >= 9.4 including https://gitlab.winehq.org/wine/wine/-/commit/8dc5242e2998afed87bc57db5798eea85877094e to successfully download the base p4k file. Adds the Kron4ek releases so that the lug helper has a source for these as Lutris does not include any recent wine runners in its API