### PR TITLE
CLI Mode for new installs

### DIFF
--- a/lib/lutris-starcitizen.json
+++ b/lib/lutris-starcitizen.json
@@ -77,7 +77,8 @@
             "GAMEID": "umu-starcitizen",
             "STORE": "none"
           },
-          "prefer_system_libs": true
+          "prefer_system_libs": true,
+          "terminal": true
         },
         "wine": {
           "dxvk": true,


### PR DESCRIPTION
CLI mode to support wine versions for RSI Launcher 2.0