### PR TITLE
Add link to COPR repository for Fedora packaged lug-helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Keybinds are backed up to *$XDG_CONFIG_HOME/starcitizen-lug/keybinds/*
 
 **NixOS:** https://github.com/LovingMelody/nix-citizen
 
+**Fedora:** https://copr.fedorainfracloud.org/coprs/jackgreiner/lug-helper
+
 _Dependencies: **bash**, **coreutils**, **curl**, **polkit** (these should be installed by default on most distributions)_  
 _Optional Dependencies: **zenity** (for GUI)_  
 


### PR DESCRIPTION
This adds a link to the Fedora package hosted on the COPR.

I have this configured on the Fedora COPR here: https://copr.fedorainfracloud.org/coprs/jackgreiner/lug-helper