### PR TITLE
Mesa Shader Cache options

### DIFF
--- a/lib/lutris-starcitizen.json
+++ b/lib/lutris-starcitizen.json
@@ -32,7 +32,7 @@
       "script": {
         "files": [
           {
-            "client": "https://install.robertsspaceindustries.com/rel/2/RSI%20Launcher-Setup-2.0.5.exe"
+            "client": "https://install.robertsspaceindustries.com/rel/2/RSI%20Launcher-Setup-2.0.6.exe"
           }
         ],
         "game": {

--- a/lib/sc-launch.sh
+++ b/lib/sc-launch.sh
@@ -22,11 +22,14 @@ export WINEPREFIX="$HOME/Games/star-citizen"
 export WINEDLLOVERRIDES=winemenubuilder.exe=d # Prevent updates from overwriting our .desktop entries
 export WINEDEBUG=-all # Cut down on console debug messages
 export EOS_USE_ANTICHEATCLIENTNULL=1
+# Nvidia cache options
 export __GL_SHADER_DISK_CACHE=1
 export __GL_SHADER_DISK_CACHE_SIZE=1073741824
-# Extra Nvidia cache options
-#export __GL_SHADER_DISK_CACHE_PATH="/path/you/want/for/your/cache"
-#export __GL_SHADER_DISK_CACHE_SKIP_CLEANUP=true
+export __GL_SHADER_DISK_CACHE_PATH="$WINEPREFIX"
+export __GL_SHADER_DISK_CACHE_SKIP_CLEANUP=true
+# Mesa (AMD/Intel) Shader Cache Options
+export MESA_SHADER_CACHE_DIR="$WINEPREFIX"
+export MESA_SHADER_CACHE_MAX_SIZE=10G
 #export DXVK_HUD=fps,compiler
 #export MANGOHUD=1
 

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -250,7 +250,7 @@ lug_wiki="https://starcitizen-lug.github.io"
 lug_wiki_nixos="https://github.com/starcitizen-lug/knowledge-base/wiki/Tips-and-Tricks#nixos"
 
 # RSI Installer version and url
-rsi_installer="RSI Launcher-Setup-2.0.5.exe"
+rsi_installer="RSI Launcher-Setup-2.0.6.exe"
 rsi_installer_url="https://install.robertsspaceindustries.com/rel/2/$rsi_installer"
 
 # Winetricks download url


### PR DESCRIPTION
Add Mesa Shader Cache Options to custom Wine launch script and update options to download the RSI 2.0.6 launcher.