### PR TITLE
lug-helper.sh: Pin winetricks version to 20250102

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -232,7 +232,8 @@ rsi_installer="RSI Launcher-Setup-2.1.1.exe"
 rsi_installer_url="https://install.robertsspaceindustries.com/rel/2/$rsi_installer"
 
 # Winetricks download url
-winetricks_url="https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks"
+winetricks_version="20250102"
+winetricks_url="https://raw.githubusercontent.com/Winetricks/winetricks/refs/tags/$winetricks_version/src/winetricks"
 
 # Github repo and script version info
 repo="starcitizen-lug/lug-helper"


### PR DESCRIPTION
I added a simple version variable to ensure we only download the same version of winetricks every time.

Since all the verbs being used during setup have stabilized and will grab their latest versions from GitHub (DXVK and the powershell wrapper come to mind) it makes sense to pin the version of winetricks being used for the sake of repeatable wineprefix installs.

This would protect against bugs like: https://github.com/Winetricks/winetricks/issues/2325 which until https://github.com/Winetricks/winetricks/pull/2326 is merged will cause wineprefix installs to fail for no reason.