### PR TITLE
preflight lutris runner check

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -932,7 +932,7 @@ lutris_check() {
             preflight_pass+=("Lutris is installed and sufficiently up to date.")
         fi
 
-        if ["$lutris_native_runner" == "$lutris_runner_required" ]; then
+        if ["$lutris_native_runner" = "$lutris_runner_required" ]; then
             # All good
             preflight_pass+=("Lutris runner is set to $lutris_runner.")
         else
@@ -967,7 +967,7 @@ lutris_check() {
             preflight_pass+=("Flatpak Lutris is installed and sufficiently up to date.")
         fi
 
-        if [ "$lutris_flatpak_runner" == "$lutris_runner_required" ]; then
+        if [ "$lutris_flatpak_runner" = "$lutris_runner_required" ]; then
             # All good
             preflight_pass+=("Flatpak Lutris runner is set to $lutris_runner.")
         else
@@ -1006,7 +1006,7 @@ lutris_detect() {
         lutris_installed="true"
         lutris_native="true"
         if [ -f  "$lutris_native_wine_yml" ]; then
-            lutris_native_runner="$(sed -En '/^wine:/,/^[^[:space:]]/ { /^[[:space:]]*version:/s/^[[:space:]]*version:[[:space:]]*//p }' "$lutris_native_wine_yml")"
+            lutris_native_runner="$(sed -En '/^wine:/,/^[^[:blank:]]/ { /^[[:blank:]]*version:/s/^[[:blank:]]*version:[[:blank:]]*//p }' "$lutris_native_wine_yml")"
         fi
     fi
 
@@ -1015,7 +1015,7 @@ lutris_detect() {
         lutris_installed="true"
         lutris_flatpak="true"
         if [ -f "$lutris_flatpak_wine_yml" ]; then
-            lutris_flatpak_runner="$(sed -En '/^wine:/,/^[^[:space:]]/ { /^[[:space:]]*version:/s/^[[:space:]]*version:[[:space:]]*//p }' "$lutris_flatpak_wine_yml")"
+            lutris_flatpak_runner="$(sed -En '/^wine:/,/^[^[:blank:]]/ { /^[[:blank:]]*version:/s/^[[:blank:]]*version:[[:blank:]]*//p }' "$lutris_flatpak_wine_yml")"
         fi
     fi
 }
@@ -1033,8 +1033,8 @@ lutris_set_runner() {
         # This assumes an indent of two spaces before the key:value pair
     elif ! grep -q "^wine:" "$1"; then
         # If wine: group doesnt exist append it with the version: node
-        preflight_user_actions+=("printf 'wine:\n  version: $lutris_runner_required\n' >> '$1'")
-    elif [ -z "$(sed -En '/^wine:/,/^[^[:space:]]/ { /^[[:space:]]*version:/p }' "$1")" ]; then
+        preflight_user_actions+=("printf '\nwine:\n  version: $lutris_runner_required\n' >> '$1'")
+    elif [ -z "$(sed -En '/^wine:/,/^[^[:blank:]]/ { /^[[:blank:]]*version:/p }' "$1")" ]; then
         # If system: node doesn't exist, add it at the start of the wine: grouping
         preflight_user_actions+=("sed -i -e '/^wine:/a\' -e \"  ${version_sed_string}${lutris_runner_required}\" '$1'")
     else


### PR DESCRIPTION
lutris still ships wine-ge 8-26 as the default wine runner and lutris has removed the means to override it from a lutris installer file. The RSI Launcher needs at least wine 9.4 to install the game successfully

this checks the lutris global default wine runner version during preflight and offers to override it to a required version automatically

- if the lutris runtime dir is empty, warn the user to run lutris first

- if the lutris wine global runner has been set, retrieve it during lutris_detect()

- if the lutris global runner matches the required runner, report all is well to preflight, otherwise offer to correct it
  - if the wine yml doesnt exist or does not contain the wine node then populate the required runner
  - if the wine node exists but not the version node then add the required runner under the wine node
  - if the wine and version nodes exist but is not the correct one then replace version with the required runner