### PR TITLE
Add the keywords "Star Citizen" and "StarCitizen" to the .desktop file to improve searchability

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -2390,6 +2390,7 @@ install_game_wine() {
 Name=RSI Launcher
 Type=Application
 Comment=RSI Launcher
+Keywords=Star Citizen;StarCitizen
 Icon=rsi-launcher.png
 Exec=\"$installed_launch_script\"
 Path=$(echo $install_dir | sed 's/ /\\\s/g')/dosdevices/c:/Program\sFiles/Roberts\sSpace\sIndustries/RSI\sLauncher" > "$localshare_desktop_file"


### PR DESCRIPTION
Currently, the `.desktop` file is only searchable by the name and comment "RSI Launcher".
With the simple addition of [keywords](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html#key-keywords), searching "Star Citizen" (or any variation) will also result in the RSI launcher as expected by most people.