### PR TITLE
Add support for user-configurable, per-prefix launch parameters

### DIFF
--- a/lib/sc-launch.cfg.example
+++ b/lib/sc-launch.cfg.example
@@ -1,0 +1,17 @@
+#############################################
+# Instructions:
+# - Copy this file into your prefix directory and name it `sc-launch.cfg`;
+#   for example `$WINEPREFIX/sc-launch.cfg`.
+# - Edit the settings below to suit your personal system.
+#
+# Values:
+# - `USE_*` = `y` to Enable or `n` to Disable.
+# - `*_ARGS` = Space-separated argument list.
+#############################################
+
+# GameMode:
+USE_GAMEMODE=y
+
+# Gamescope:
+USE_GAMESCOPE=y
+GAMESCOPE_ARGS="--hdr-enabled -W 2560 -H 1440 --force-grab-cursor"

--- a/lib/sc-launch.sh
+++ b/lib/sc-launch.sh
@@ -87,7 +87,28 @@ update_check() {
 ################################################################################
 # Launch the game
 ################################################################################
-# To enable gamescope, replace the launch line below. For example:
-# gamescope --hdr-enabled -W 2560 -H 1440 --force-grab-cursor "$wine_path"/wine "C:\Program Files\Roberts Space Industries\RSI Launcher\RSI Launcher.exe" > "$launch_log" 2>&1
+# Load user configuration (if found; optional).
+# To use your own custom configuration, please look at "sc-launch.cfg.example".
+cfg_file="$WINEPREFIX/sc-launch.cfg"
+if [ -f "$cfg_file" ]; then
+    source "$cfg_file"
+fi
 
-"$wine_path"/wine "C:\Program Files\Roberts Space Industries\RSI Launcher\RSI Launcher.exe" > "$launch_log" 2>&1
+# Build dynamic launch command based on user's configuration.
+declare -a launch_cmd=()
+
+if [ "${USE_GAMEMODE:-}" = "y" ]; then
+    launch_cmd+=("gamemoderun")
+fi
+
+if [ "${USE_GAMESCOPE:-}" = "y" ]; then
+    launch_cmd+=("gamescope")
+    if [ -n "${GAMESCOPE_ARGS:-}" ]; then
+        launch_cmd+=(${GAMESCOPE_ARGS})
+    fi
+fi
+
+launch_cmd+=("$wine_path/wine")
+launch_cmd+=("C:\Program Files\Roberts Space Industries\RSI Launcher\RSI Launcher.exe")
+
+"${launch_cmd[@]}" > "$launch_log" 2>&1


### PR DESCRIPTION
Adds support for per-prefix launch configurations, enabling users to easily configure the LUG startup process without needing to edit the launch script itself.

This new feature also makes it possible to create a GUI configuration editor in `lug-helper` as a followup feature. That editor would then modify the prefix's launch-configuration file.

---

To see what it's doing, and what each argument contains, you can replace the final "launch" line with this instead during local testing:

```sh
for ((i = 0; i < ${#launch_cmd[@]}; i++))
do
    echo "${i}: ${launch_cmd[$i]}"
done
```

---

Example launch arguments if the provided example config is used by a user:

```
0: gamemoderun
1: gamescope
2: --hdr-enabled
3: -W
4: 2560
5: -H
6: 1440
7: --force-grab-cursor
8: /path/to/wine
9: C:\Program Files\Roberts Space Industries\RSI Launcher\RSI Launcher.exe
```

And if the user doesn't install a config:

```
0: /path/to/wine
1: C:\Program Files\Roberts Space Industries\RSI Launcher\RSI Launcher.exe
```