### PR TITLE
Reduce the memory-mapped page limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Keybinds are backed up to *$XDG_CONFIG_HOME/starcitizen-lug/keybinds/*
 
 `Preflight Check`
 - Runs a series of system optimization checks and offers to fix any issues
-  - Checks that vm.max_map_count is set to at least 16777216
+  - Checks that vm.max_map_count is set to at least 1048576
     - This sets the maxmimum number of "memory map areas" a process can have. While most applications need less than a thousand maps, Star Citizen requires access to more
   - Checks that the hard open file descriptors limit is set to at least 524288
     - This limits the maximum number of open files on your system.  On some Linux distributions, the default is set too low for Star Citizen

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -1002,30 +1002,30 @@ avx_check() {
 mapcount_check() {
     mapcount="$(cat /proc/sys/vm/max_map_count)"
     # Add to the results and actions arrays
-    if [ "$mapcount" -ge 16777216 ]; then
+    if [ "$mapcount" -ge 1048576 ]; then
         # All good
         preflight_pass+=("vm.max_map_count is set to $mapcount.")
     elif grep -E -x -q "vm.max_map_count" /etc/sysctl.conf /etc/sysctl.d/* 2>/dev/null; then
         # Was it supposed to have been set by sysctl?
-        preflight_fail+=("vm.max_map_count is configured to at least 16777216 but the setting has not been loaded by your system.")
+        preflight_fail+=("vm.max_map_count is configured to at least 1048576 but the setting has not been loaded by your system.")
         # Add the function that will be called to change the configuration
         preflight_action_funcs+=("mapcount_once")
 
         # Add info for manually changing the setting
-        preflight_manual+=("To change vm.max_map_count until the next reboot, run:\nsudo sysctl -w vm.max_map_count=16777216")
+        preflight_manual+=("To change vm.max_map_count until the next reboot, run:\nsudo sysctl -w vm.max_map_count=1048576")
     else
         # The setting should be changed
-        preflight_fail+=("vm.max_map_count is $mapcount\nand should be set to at least 16777216\nto give the game access to sufficient memory.")
+        preflight_fail+=("vm.max_map_count is $mapcount\nand should be set to at least 1048576\nto give the game access to sufficient memory.")
         # Add the function that will be called to change the configuration
         preflight_action_funcs+=("mapcount_set")
 
         # Add info for manually changing the setting
         if [ -d "/etc/sysctl.d" ]; then
             # Newer versions of sysctl
-            preflight_manual+=("To change vm.max_map_count permanently, add the following line to\n'/etc/sysctl.d/99-starcitizen-max_map_count.conf' and reload with 'sudo sysctl --system'\n    vm.max_map_count = 16777216\n\nOr, to change vm.max_map_count temporarily until next boot, run:\n    sudo sysctl -w vm.max_map_count=16777216")
+            preflight_manual+=("To change vm.max_map_count permanently, add the following line to\n'/etc/sysctl.d/99-starcitizen-max_map_count.conf' and reload with 'sudo sysctl --system'\n    vm.max_map_count = 1048576\n\nOr, to change vm.max_map_count temporarily until next boot, run:\n    sudo sysctl -w vm.max_map_count=1048576")
         else
             # Older versions of sysctl
-            preflight_manual+=("To change vm.max_map_count permanently, add the following line to\n'/etc/sysctl.conf' and reload with 'sudo sysctl -p':\n    vm.max_map_count = 16777216\n\nOr, to change vm.max_map_count temporarily until next boot, run:\n    sudo sysctl -w vm.max_map_count=16777216")
+            preflight_manual+=("To change vm.max_map_count permanently, add the following line to\n'/etc/sysctl.conf' and reload with 'sudo sysctl -p':\n    vm.max_map_count = 1048576\n\nOr, to change vm.max_map_count temporarily until next boot, run:\n    sudo sysctl -w vm.max_map_count=1048576")
         fi
     fi
 }
@@ -1035,11 +1035,11 @@ mapcount_check() {
 mapcount_set() {
     if [ -d "/etc/sysctl.d" ]; then
         # Newer versions of sysctl
-        preflight_root_actions+=('printf "\n# Added by LUG-Helper:\nvm.max_map_count = 16777216\n" > /etc/sysctl.d/99-starcitizen-max_map_count.conf && sysctl --quiet --system')
+        preflight_root_actions+=('printf "\n# Added by LUG-Helper:\nvm.max_map_count = 1048576\n" > /etc/sysctl.d/99-starcitizen-max_map_count.conf && sysctl --quiet --system')
         preflight_fix_results+=("The vm.max_map_count configuration has been added to:\n/etc/sysctl.d/99-starcitizen-max_map_count.conf")
     else
         # Older versions of sysctl
-        preflight_root_actions+=('printf "\n# Added by LUG-Helper:\nvm.max_map_count = 16777216" >> /etc/sysctl.conf && sysctl -p')
+        preflight_root_actions+=('printf "\n# Added by LUG-Helper:\nvm.max_map_count = 1048576" >> /etc/sysctl.conf && sysctl -p')
         preflight_fix_results+=("The vm.max_map_count configuration has been added to:\n/etc/sysctl.conf")
     fi
 
@@ -1050,7 +1050,7 @@ mapcount_set() {
 # MARK: mapcount_once()
 # Sets vm.max_map_count for the current session only
 mapcount_once() {
-    preflight_root_actions+=('sysctl -w vm.max_map_count=16777216')
+    preflight_root_actions+=('sysctl -w vm.max_map_count=1048576')
     preflight_fix_results+=("vm.max_map_count was changed until the next boot.")
     preflight_followup+=("mapcount_confirm")
 }
@@ -1058,7 +1058,7 @@ mapcount_once() {
 # MARK: mapcount_confirm()
 # Check if setting vm.max_map_count was successful
 mapcount_confirm() {
-    if [ "$(cat /proc/sys/vm/max_map_count)" -lt 16777216 ]; then
+    if [ "$(cat /proc/sys/vm/max_map_count)" -lt 1048576 ]; then
         preflight_fix_results+=("WARNING: As far as this Helper can detect, vm.max_map_count\nwas not successfully configured on your system.\nYou will most likely experience crashes.")
     fi
 }


### PR DESCRIPTION
Uses a safer and more user-friendly value. Many modern distros already use this value by default, thus reducing the lug-helper setup hassle for new users since they won't have to tweak their already-working configurations.

---

Detailed information:

- Star Citizen doesn't use more than 52000 VMA pages (active memory mapped handles). It constantly frees the memory-mapped files when you leave areas and no longer need those textures/models. It typically hovers around 49000 VMA pages in use. While the number might grow in certain areas, it's clearly being managed well by the game (constant releasing of memory), and the game clearly doesn't contain that many resource files, so growth beyond this is not expected to exceed 2x.
- The "16777216" (16 million) handles enforced by lug-helper is therefore 322x higher than necessary.
- The 1 million handles used by default on Fedora, Manjaro, Ubuntu (since 24.04) and many other distros is very overkill too, but is more reasonable.
- There is no need to tell users to rewrite their value to the nonsensical 16 million. It not only causes more hassle for users whose distros already have a perfect value by default (1 million) - it can also crash the kernel by allowing malicious/bugged user-level processes to consume all RAM. This can also be used for a denial-of-service attack by uploading a binary on a multi-user machine and then memory-mapping files infinitely. Even the 1 million handle limit will crash a machine that has less than 2 gigabytes of RAM. The 16 million handle limit would allow a bugged process to consume exponentially more RAM than that (the kernel's growth in RAM usage and CPU usage from higher limits is logarithmic).

So it's time to put that old "magic number" to rest and revert to 1 million (`1048576`), which is the number that modern distros have settled on and are already pre-configured to use with zero intervention by the users. And even that amount is very overkill, which is easy to confirm via the method below:

https://pagure.io/fesco/issue/2993#comment-983319

---

## Checklist
<!-- Put an `x` the boxes to check them off -->
- [x] I've read the [Contributor's Guide](https://github.com/starcitizen-lug/lug-helper?tab=contributing-ov-file)
- [x] I have fully tested this PR
- [x] The code is well documented
