### PR TITLE
Few fixes for RSI Laucher desktop file.

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -2479,9 +2479,8 @@ Comment=RSI Launcher
 Keywords=Star Citizen;StarCitizen
 StartupNotify=true
 StartupWMClass=rsi launcher.exe
-Icon=rsi-launcher.png
-Exec=\"$installed_launch_script\"
-Path=$(echo "$install_dir" | sed 's/ /\\\s/g')/dosdevices/c:/Program\sFiles/Roberts\sSpace\sIndustries/RSI\sLauncher" > "$prefix_desktop_file"
+Icon=rsi-launcher
+Exec=\"$installed_launch_script\"" > "$prefix_desktop_file"
 
     # Copy the new desktop file to ~/.local/share/applications
     mkdir -p "$data_dir/applications"


### PR DESCRIPTION
## Current behavior

- The icon for `RSI Laucher.deskop` file is currently broken (at least on Arch) due to the extension being present in the `.desktop` file. (See [Icon Theme Specification - Icon Lookup](https://specifications.freedesktop.org/icon-theme-spec/latest/#icon_lookup)
- The `Path` field should be used to indicate the working directory for the `Exec` field. Which currenly does not point to the install location of `sc-launch.sh`. Preventing the use of the desktop file from an app launcher. (See [Recognized desktop entry keys](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html#id-1.7.6)) 

## Changes made

- Removed the extension in the `Icon` field.
- Removed the `Path` field.

## Other information

The `Path` field may be kept if needed within the Wine prefix, but I had no problems changing boths will testing.

## Checklist

- [x] I've read the [Contributor's Guide](https://github.com/starcitizen-lug/lug-helper?tab=contributing-ov-file)
- [x] I have fully tested this PR
- [x] The code is well documented
