### PR TITLE
Adding a `noconfirm` option

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -3211,6 +3211,7 @@ Usage: lug-helper <options>
   -w, --show-wiki               Show the LUG Wiki
   -x, --reset-helper            Delete saved lug-helper configs
   -g, --no-gui                  Use terminal menus instead of a Zenity GUI
+  -nc, --noconfirm              Ignore all question prompts and proceed
   -v, --version                 Display version info and exit
 "
                 exit 0


### PR DESCRIPTION
## Current behavior
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
The implemented feature does not exist.

## Changes made
<!-- Please describe the changes made by this PR -->
This implements a simple `noconfirm` argument to the helper, allowing users to run the helper without the need to confirm every action. 

This works in the following way: If the user adds `-nc` or `--no-confirm` to their command, e.g. `lug-helper -g -nc -i`, the script will ignore all confirmation prompts and automatically accept them.

## Other information
<!-- Any other information that is important to this PR -->
The only big problem I see with the current approach is that there is no way to stop certain confirmations from being ignored. It would probably be possible to add something to the `message` function (like another variable check that was set before) that would ignore the noconfirm option. I would see use for this in error messages or really really important things.

I have tested this on arch linux and it worked without problems. I also tried to add the needed documentation as well as the usage to the message prompted on `lug-helper --help`. I also tried to change as little as possible in the code to get this basic function in.

## Checklist
<!-- Put an `x` the boxes to check them off -->
- [x] I've read the [Contributor's Guide](https://github.com/starcitizen-lug/lug-helper?tab=contributing-ov-file)
- [x] I have fully tested this PR
- [x]  The code is well documented
