### PR TITLE
Consistent "back" option in terminal menus

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -803,7 +803,23 @@ getdirs() {
 }
 
 # MARK: dedent()
-# Remove leading whitespace from stdin
+# Remove leading whitespace from stdin to de-indent the text.
+#
+# For example:
+#
+# ```
+#     foo
+#   bar
+#       baz
+# ```
+#
+# Would become:
+#
+# ```
+#   foo
+# bar
+#     baz
+# ```
 dedent() {
     awk '
         BEGIN { is_first_match = 1 }

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -24,12 +24,23 @@ fi
 
 # Check for dependencies
 if [ ! -x "$(command -v curl)" ]; then
-# Print to stderr and also try warning the user through zenity or notify-send
+    # Print to stderr and also try warning the user through zenity or notify-send
     printf "lug-helper.sh: The required package 'curl' was not found on this system.\n" 1>&2
     if [ -x "$(command -v zenity)" ]; then
         zenity --error --width="400" --title="Star Citizen LUG Helper" --text="The required package 'curl' was not found on this system."
     elif [ -x "$(command -v notify-send)" ]; then
         notify-send "lug-helper" "The required package 'curl' was not found on this system.\n" --icon=dialog-warning
+    fi
+    exit 1
+fi
+if [ ! -x "$(command -v column)" ]; then
+    # util-linux
+    # Print to stderr and also try warning the user through zenity or notify-send
+    printf "lug-helper.sh: One or more required packages were not found on this system.\nPlease check that 'util-linux' or the following packages are installed:\n- column\n" 1>&2
+    if [ -x "$(command -v zenity)" ]; then
+        zenity --error --width="400" --title="Star Citizen LUG Helper" --text="One or more required packages were not found on this system.\n\nPlease check that 'util-linux' or the following packages are installed:\n- column"
+    elif [ -x "$(command -v notify-send)" ]; then
+        notify-send "lug-helper" "One or more required packages were not found on this system.\nPlease check that 'util-linux' or the following packages are installed:\n- column\n" --icon=dialog-warning
     fi
     exit 1
 fi

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -464,6 +464,10 @@ progress_bar() {
 # Requires the following variables:
 # - The array "menu_options" should contain the strings of each option.
 # - The array "menu_actions" should contain function names to be called.
+# - The last item in the "menu_options" and "menu_actions" array must be the
+#   "back"/"quit"/"cancel" option. In Zenity, this will be used when the user
+#   clicks the "cancel" button, in bash it will be displayed as the first menu
+#   item.
 # - The strings "menu_text_zenity" and "menu_text_terminal" should contain
 #   the menu description formatted for zenity and the terminal, respectively.
 #   This text will be displayed above the menu options.

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -44,7 +44,7 @@ if [ ! -x "$(command -v column)" ]; then
     fi
     exit 1
 fi
-if [ ! -x "$(command -v mktemp)" ] || [ ! -x "$(command -v touch)" ] || [ ! -x "$(command -v chmod)" ] || [ ! -x "$(command -v sort)" ] || [ ! -x "$(command -v basename)" ] || [ ! -x "$(command -v realpath)" ] || [ ! -x "$(command -v dirname)" ] || [ ! -x "$(command -v cut)" ] || [ ! -x "$(command -v numfmt)" ] || [ ! -x "$(command -v tr)" ]; then
+if [ ! -x "$(command -v mktemp)" ] || [ ! -x "$(command -v touch)" ] || [ ! -x "$(command -v chmod)" ] || [ ! -x "$(command -v sort)" ] || [ ! -x "$(command -v basename)" ] || [ ! -x "$(command -v realpath)" ] || [ ! -x "$(command -v dirname)" ] || [ ! -x "$(command -v cut)" ] || [ ! -x "$(command -v numfmt)" ] || [ ! -x "$(command -v tr)" ] || [ ! -x "$(command -v wc)" ]; then
     # coreutils
     # Print to stderr and also try warning the user through zenity or notify-send
     printf "lug-helper.sh: One or more required packages were not found on this system.\nPlease check that 'coreutils' is installed!\n" 1>&2

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -602,6 +602,7 @@ menu() {
 
             # Pint the menu header
             printf "\n%b\n\n" "$menu_text_terminal"
+
             # Print the menu items
             (
                 local pad_len
@@ -610,7 +611,8 @@ menu() {
                 for (( i=0; i<"${#menu_options[@]}"; i++ )); do
                     printf "%${pad_len}d) %s\n" "$((i+1))" "${menu_options[i]}"
                 done
-            ) | column -S 4
+            ) | column -S 4 -c "${COLUMNS:-80}" | dedent
+
             # Print the cancel option
             printf "\n0) %s" "$menu_cancel_label"
             printf "\nq) Quit LUG-Helper"
@@ -798,6 +800,35 @@ getdirs() {
     fi
 
     return "$retval"
+}
+
+# MARK: dedent()
+# Remove leading whitespace from stdin
+dedent() {
+    awk '
+        BEGIN { is_first_match = 1 }
+
+        # Runs only for lines with non-whitespace content
+        NF {
+            # Match whitespace at the beginning of the line
+            match($0, /^[[:space:]]*/);
+            # Get the length of the match
+            ind = RLENGTH;
+            # Get the minimum indentation
+            min = (is_first_match == 1 || ind < min) ? ind : min
+            is_first_match = 0
+        }
+
+        # Runs for all lines: Save all lines for later
+        { lines[NR] = $0 }
+
+        # Finally, print the lines and remove leading whitespaces
+        END {
+            for (i = 1; i <= NR; i++) {
+                print substr(lines[i], min + 1)
+            }
+        }
+    '
 }
 
 

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -604,8 +604,11 @@ menu() {
             printf "\n%b\n\n" "$menu_text_terminal"
             # Print the menu items
             (
+                local pad_len
+                pad_len="$(echo -n "${#menu_options[@]}" | wc -c)"
+
                 for (( i=0; i<"${#menu_options[@]}"; i++ )); do
-                    printf "%d) %s\n" "$((i+1))" "${menu_options[i]}"
+                    printf "%${pad_len}d) %s\n" "$((i+1))" "${menu_options[i]}"
                 done
             ) | column -S 4
             # Print the cancel option

--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -612,7 +612,9 @@ menu() {
                 done
             ) | column -S 4
             # Print the cancel option
-            printf "\n0) %s\n\n" "$menu_cancel_label"
+            printf "\n0) %s" "$menu_cancel_label"
+            printf "\nq) Quit LUG-Helper"
+            printf "\n\n"
 
             if [[ -n $error ]]; then
                 # Display error message
@@ -621,6 +623,11 @@ menu() {
             fi
 
             read -r -p 'Enter selection number: ' input
+
+            if [[ $input == 'q' ]]; then
+                # User selected the quit option
+                quit
+            fi
 
             if [[ $input == '0' ]]; then
                 # User selected the cancel option


### PR DESCRIPTION
## Current behavior

When using lug-helper on the terminal (without Zenity), the "back" option is always the last option in the list and therefore the number that needs to be entered to go back always changes  depending on how many other options there are.

## Changes made

This PR introduces a new text-menu renderer that 
- (like the Zenity renderer) assumes that the last option is always the "back" option and displays it with the selection number `0` at the bottom of the menu
- Adds a global "quit" option at the bottom of the menu that allows to exit lug-helper from any menu by typing `q` 

The new menu renderer should look and feel like the current one except that it shows two extra options at the bottom for going back and quitting lug-helper. It also clears the screen before it re-renders the menu when an invalid option is typed.

Example (with error message for invalid input `asdf`):

```
Select the runner you want to install:

 1) lug-wine-tkg-git-11.0-1    [installed]     14) lug-wine-tkg-staging-git-10.20-1
 2) lug-wine-tkg-staging-git-11.0-1            15) lug-wine-tkg-git-10.19-1
 3) lug-wine-tkg-git-11.0rc3-1                 16) lug-wine-tkg-staging-git-10.19-1
 4) lug-wine-tkg-staging-git-11.0rc3-1         17) lug-wine-tkg-git-10.18-2
 5) lug-wine-tkg-git-11.0rc1-2                 18) lug-wine-tkg-staging-git-10.18-2
 6) lug-wine-tkg-staging-git-11.0rc1-2         19) lug-wine-tkg-fsync-git-10.16-1
 7) lug-wine-tkg-git-11.0rc1-1                 20) lug-wine-tkg-ntsync-git-10.16-1
 8) lug-wine-tkg-staging-git-11.0rc1-1         21) lug-wine-tkg-staging-fsync-git-10.16-1
 9) lug-wine-tkg-git-10.20-3                   22) lug-wine-tkg-staging-ntsync-git-10.16-1
10) lug-wine-tkg-staging-git-10.20-3           23) lug-wine-tkg-fsync-git-10.15-1
11) lug-wine-tkg-git-10.20-2                   24) lug-wine-tkg-ntsync-git-10.15-1
12) lug-wine-tkg-staging-git-10.20-2           25) lug-wine-tkg-staging-fsync-git-10.15-1
13) lug-wine-tkg-git-10.20-1

0) Return to the runner management menu
q) Quit LUG-Helper

=> Invalid selection: asdf

Enter selection number: 
```

## Other information

This PR adds another helper function `dedent` that should be added to the [Code Structure and Overview](https://github.com/starcitizen-lug/lug-helper/wiki/Code-Structure-and-Overview) wiki page. I'd suggest putting it in the "Messaging and menu building" section.

## Checklist
<!-- Put an `x` the boxes to check them off -->
- [x] I've read the [Contributor's Guide](https://github.com/starcitizen-lug/lug-helper?tab=contributing-ov-file)
- [x] I have fully tested this PR
- [x] The code is well documented
