### PR TITLE
Allow to disable the NixOS startup warning

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -3340,8 +3340,11 @@ if (grep -q '^NAME=NixOS' /etc/os-release 2> /dev/null ); then
     fi
     if [ "$show_nixos_startup_warning" != "false" ]; then
         show_nixos_startup_warning=true
-        disable_instructions="You can disable this warning by going to '${menu_item__maintenance_and_troubleshooting}' > '${menu_item__maintenance_and_troubleshooting__disable_nixos_startup_warning}'."
-        message info "It looks like you're using NixOS\nPlease see our wiki for NixOS-specific configuration requirements:\n\n$lug_wiki_nixos\n\n$disable_instructions"
+        message="It looks like you're using NixOS\n"
+        message+="Please see our wiki for NixOS-specific configuration requirements:\n\n"
+        message+="${lug_wiki_nixos}\n\n"
+        message+="You can disable this warning by navigating to '${menu_item__maintenance_and_troubleshooting}' > '${menu_item__maintenance_and_troubleshooting__disable_nixos_startup_warning}'."
+        message info "$message"
     fi
 fi
 


### PR DESCRIPTION
## Current behavior

On NixOS there's a warning every time lug-helper is started with a wiki link to the NixOS installation section.

## Changes made

This PR adds an option under "Maintenance and Troubleshooting" to disable (and then also re-enable) the NixOS startup warning.

## Other information

This PR adds a function `set_nixos_startup_warning` that should be added to the "Maintenance menu functions" section of the [Code Structure and Overview](https://github.com/starcitizen-lug/lug-helper/wiki/Code-Structure-and-Overview) wiki page.

I use the menu item texts "Maintenance and Troubleshooting" and "Disable NixOS warning at startup" in in the warning text to describe how to disable this warning. Therefore I've extracted them into variables so the message does not diverge from the menu names, should the menu names be changed.

## Checklist
<!-- Put an `x` the boxes to check them off -->
- [x] I've read the [Contributor's Guide](https://github.com/starcitizen-lug/lug-helper?tab=contributing-ov-file)
- [x] I have fully tested this PR
- [x] The code is well documented
